### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 2025-01-08
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "batch-ai",
-  "version": "0.1.7",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "batch-ai",
-      "version": "0.1.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "batch-ai",
-  "version": "0.1.7",
+  "version": "1.0.0",
   "description": "A unified SDK for making batch AI requests across different model providers",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
BREAKING CHANGE: Input format changed from string to ContentPart[] for all providers

- Add image support for batch requests
- Unify input format across OpenAI and Anthropic providers
- See CHANGELOG.md for migration guide